### PR TITLE
fix: support placeholders next to each other

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,16 +52,19 @@ function format(f, args, opts) {
           var type = typeof args[a]
           if (type === 'string') {
             str += '\'' + args[a] + '\''
-            lastPos = i = i + 2
+            lastPos = i + 2
+            i++
             break
           }
           if (type === 'function') {
             str += args[a].name || '<anonymous>'
-            lastPos = i = i + 2
+            lastPos = i + 2
+            i++
             break
           }
           str += ss(args[a])
-          lastPos = i = i + 2
+          lastPos = i + 2
+          i++
           break
         case 115: // 's'
           if (a >= argLen)
@@ -69,13 +72,15 @@ function format(f, args, opts) {
           if (lastPos < i)
             str += f.slice(lastPos, i)
           str += String(args[a])
-          lastPos = i = i + 2
+          lastPos = i + 2
+          i++
           break
         case 37: // '%'
           if (lastPos < i)
             str += f.slice(lastPos, i)
           str += '%'
-          lastPos = i = i + 2
+          lastPos = i + 2
+          i++
           break
       }
       ++a

--- a/test/index.js
+++ b/test/index.js
@@ -56,6 +56,11 @@ assert.equal(format('%s:%s', [undefined]), 'undefined:%s');
 assert.equal(format('%s:%s', ['foo']), 'foo:%s');
 assert.equal(format('%s:%s', ['foo', 'bar']), 'foo:bar');
 assert.equal(format('%s:%s', ['foo', 'bar', 'baz']), 'foo:bar baz');
+assert.equal(format('%s%s', []), '%s%s');
+assert.equal(format('%s%s', [undefined]), 'undefined%s');
+assert.equal(format('%s%s', ['foo']), 'foo%s');
+assert.equal(format('%s%s', ['foo', 'bar']), 'foobar');
+assert.equal(format('%s%s', ['foo', 'bar', 'baz']), 'foobar baz');
 // // assert.equal(format(['%%%s%%', 'hi']), '%hi%');
 // // assert.equal(format(['%%%s%%%%', 'hi']), '%hi%%');
 


### PR DESCRIPTION
If a placehodler match is found, instead of incrementing both `lastPos` and `i` by two, we have to increment only `lastPos` by two, and `i` by one, because `i` is also incremented by one again by the end of the loop.

Before this fix, `i` would have been incremented by three which caused the second placeholder to be skipped.

Fixes #18