### PR TITLE
Fix behaviour when fmt param is null.

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ function format(f, args, opts) {
   var str = ''
   var a = 1 - offset
   var lastPos = 0
-  var flen = f.length
+  var flen = (f && f.length) || 0
   for (var i = 0; i < flen;) {
     if (f.charCodeAt(i) === 37 && i + 1 < flen) {
       switch (f.charCodeAt(i + 1)) {

--- a/test/index.js
+++ b/test/index.js
@@ -61,6 +61,13 @@ assert.equal(format('%s%s', [undefined]), 'undefined%s');
 assert.equal(format('%s%s', ['foo']), 'foo%s');
 assert.equal(format('%s%s', ['foo', 'bar']), 'foobar');
 assert.equal(format('%s%s', ['foo', 'bar', 'baz']), 'foobar baz');
+
+assert.equal(format(null, ['foo', null, 'bar']), 'foo null bar');
+assert.equal(format(null, ['foo', undefined, 'bar']), 'foo undefined bar');
+
+assert.equal(format(null, [null, 'foo']), 'null foo');
+assert.equal(format(null, [undefined, 'foo']), 'undefined foo');
+
 // // assert.equal(format(['%%%s%%', 'hi']), '%hi%');
 // // assert.equal(format(['%%%s%%%%', 'hi']), '%hi%%');
 


### PR DESCRIPTION
This PR is related the following issue on pino: [595](https://github.com/pinojs/pino/issues/595)

When the fmt param is null, the code assumes that the first args element is the new fmt.
This makes the module have the following behaviour:

Example:
```
format(null, ['foo %s', 'bar %s', 'baz']) 
```
Output:
```
'foo bar %s baz'
```
But a problem arises when the arg[0] is also null, throwing a TypeError.
```
format(null, [null, 'foo']) 
```
```
TypeError: Cannot read property 'length' of null
    at format (quick-format-unescaped/index.js:31:16)
```
This is inconsistent with this case that doesn't throw:
```
format(null, ['foo', null]) 
```
Output:
```
'foo null'
```

This commit tries to fix that. A call like format(null, [null, 'foo']) will return 'null foo'.