### PR TITLE
Return empty string when called with no args

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,8 +22,8 @@ function format(f, args, opts) {
     }
     return objects.join(' ')
   }
-  var argLen = args.length
-  if (argLen === 0) return f
+  var argLen = args ? args.length : 0
+  if (argLen === 0) return f === undefined ? '' : f
   var x = ''
   var str = ''
   var a = 1 - offset

--- a/test/index.js
+++ b/test/index.js
@@ -1,6 +1,8 @@
 'use strict';
 const assert = require('assert');
 const format = require('../');
+const util = require('util');
+
 // const symbol = Symbol('foo');
 
 // assert.equal(format([]), '');
@@ -67,6 +69,7 @@ assert.equal(format(null, ['foo', undefined, 'bar']), 'foo undefined bar');
 
 assert.equal(format(null, [null, 'foo']), 'null foo');
 assert.equal(format(null, [undefined, 'foo']), 'undefined foo');
+assert.equal(format(), util.format());
 
 // // assert.equal(format(['%%%s%%', 'hi']), '%hi%');
 // // assert.equal(format(['%%%s%%%%', 'hi']), '%hi%%');


### PR DESCRIPTION
The result of `util.format()` is an empty string.
The result of `quick-format-unescaped.format()` is a TypeError.

```
> require('util').format()
''
> const format = require('quick-format-unescaped')
undefined
> format()
TypeError: Cannot read property 'length' of undefined
    at format (.../node_modules/quick-format-unescaped/index.js:25:21)
>
```

This PR fixes that so `''` is returned and `quick-format-unescaped.format()` more closely matches `util.format()`.