### PR TITLE
Support passing Symbol parameters

### DIFF
--- a/index.js
+++ b/index.js
@@ -95,7 +95,7 @@ function format(f, args, opts) {
   while (a < argLen) {
     x = args[a++]
     if (x === null || (typeof x !== 'object')) {
-      str += ' ' + x
+      str += ' ' + String(x)
     } else {
       str += ' ' + ss(x)
     }

--- a/test/index.js
+++ b/test/index.js
@@ -1,7 +1,6 @@
 'use strict';
 const assert = require('assert');
 const format = require('../');
-// const symbol = Symbol('foo');
 
 // assert.equal(format([]), '');
 // assert.equal(format(['']), '');
@@ -15,14 +14,15 @@ const format = require('../');
 // // // CHECKME this is for console.log() compatibility - but is it *right*?
 // assert.equal(format(['foo', 'bar', 'baz']), 'foo bar baz');
 
-// // ES6 Symbol handling
-// // assert.equal(format([symbol]), 'Symbol(foo)');
-// // assert.equal(format(['foo', symbol]), 'foo Symbol(foo)');
-// // assert.equal(format(['%s', symbol]), 'Symbol(foo)');
-// // assert.equal(format(['%j', symbol]), 'undefined');
-// // assert.throws(function() {
-// //   format(['%d', symbol]);
-// // }, TypeError);
+// ES6 Symbol handling
+const symbol = Symbol('foo')
+assert.equal(format(null, [symbol]), symbol);
+assert.equal(format('foo', [symbol]), 'foo Symbol(foo)');
+assert.equal(format('%s', [symbol]), 'Symbol(foo)');
+assert.equal(format('%j', [symbol]), 'undefined');
+assert.throws(function() {
+  format(['%d', symbol]);
+}, TypeError);
 
 assert.equal(format('%d', [42.0]), '42');
 assert.equal(format('%d', [42]), '42');


### PR DESCRIPTION
Symbols throw a TypeError when being converted to a string by way of
concatenation. So the following call:

```js
format('hello', [Symbol('a')])
```

Would have thrown a TypeError. This commit explicitly passes parameters
through the `String` function, which is the exact behaviour of the `'%s`
formatter.