### PR TITLE
No format string => no formatting

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,14 +3,13 @@ function tryStringify (o) {
   try { return JSON.stringify(o) } catch(e) { return '"[Circular]"' }
 }
 
-module.exports = format 
+module.exports = format
 
 function format(f, args, opts) {
   var ss = (opts && opts.stringify) || tryStringify
   var offset = 1
-  if (f === null) {
-    f = args[0]
-    offset = 0
+  if (typeof f !== 'string') {
+    return f
   }
   if (typeof f === 'object' && f !== null) {
     var len = args.length + offset
@@ -27,7 +26,7 @@ function format(f, args, opts) {
   var x = ''
   var str = ''
   var a = 1 - offset
-  var lastPos = 0
+  var lastPos = -1
   var flen = (f && f.length) || 0
   for (var i = 0; i < flen;) {
     if (f.charCodeAt(i) === 37 && i + 1 < flen) {
@@ -87,8 +86,8 @@ function format(f, args, opts) {
     }
     ++i
   }
-  if (lastPos === 0)
-    str = f
+  if (lastPos === -1)
+    return f
   else if (lastPos < flen) {
     str += f.slice(lastPos)
   }

--- a/test/index.js
+++ b/test/index.js
@@ -16,12 +16,12 @@ const format = require('../');
 
 // ES6 Symbol handling
 const symbol = Symbol('foo')
-assert.equal(format(null, [symbol]), symbol);
-assert.equal(format('foo', [symbol]), 'foo Symbol(foo)');
+assert.equal(format(null, [symbol]), null);
+assert.equal(format('foo', [symbol]), 'foo');
 assert.equal(format('%s', [symbol]), 'Symbol(foo)');
 assert.equal(format('%j', [symbol]), 'undefined');
 assert.throws(function() {
-  format(['%d', symbol]);
+  format('%d', [symbol]);
 }, TypeError);
 
 assert.equal(format('%d', [42.0]), '42');
@@ -61,12 +61,6 @@ assert.equal(format('%s%s', [undefined]), 'undefined%s');
 assert.equal(format('%s%s', ['foo']), 'foo%s');
 assert.equal(format('%s%s', ['foo', 'bar']), 'foobar');
 assert.equal(format('%s%s', ['foo', 'bar', 'baz']), 'foobar baz');
-
-assert.equal(format(null, ['foo', null, 'bar']), 'foo null bar');
-assert.equal(format(null, ['foo', undefined, 'bar']), 'foo undefined bar');
-
-assert.equal(format(null, [null, 'foo']), 'null foo');
-assert.equal(format(null, [undefined, 'foo']), 'undefined foo');
 
 // // assert.equal(format(['%%%s%%', 'hi']), '%hi%');
 // // assert.equal(format(['%%%s%%%%', 'hi']), '%hi%%');


### PR DESCRIPTION
The following makes no sense because there are not any format identifiers in the format string:

```js
format('foo', ['bar']) // => 'foo bar'
```

The following doesn't make any sense because invoking a function is not the same thing as using the `apply` prototype method:

```js
format(['%s', 'foo']) // => 'foo'
```

This PR removes these nonsense use cases such that:

1. yields: `'foo'`
2. yields: `null`

This PR also makes the behavior match the documentation. No where in the docs does it enumerate the currently implemented surprising behaviors.

If this PR is accepted it will resolve https://github.com/pinojs/pino/issues/793

This PR will clearly necessitate a semver major release.