### PR TITLE
Revert semver-major changes in v4

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,6 +19,9 @@ function format(f, args, opts) {
     return objects.join(' ')
   }
 
+  if (typeof f !== 'string') {
+    return f
+  }
   var argLen = args ? args.length : 0
   if (argLen === 0) return f === undefined ? '' : f
   var str = ''

--- a/index.js
+++ b/index.js
@@ -18,12 +18,11 @@ function format(f, args, opts) {
     }
     return objects.join(' ')
   }
-
   if (typeof f !== 'string') {
     return f
   }
-  var argLen = args ? args.length : 0
-  if (argLen === 0) return f === undefined ? '' : f
+  var argLen = args.length
+  if (argLen === 0) return f
   var str = ''
   var a = 1 - offset
   var lastPos = -1

--- a/test/index.js
+++ b/test/index.js
@@ -1,5 +1,5 @@
 'use strict';
-const assert = require('assert').strict;
+const assert = require('assert');
 const format = require('../');
 const util = require('util');
 
@@ -83,8 +83,8 @@ assert.equal(format('%s%s', ['foo', 'bar', 'baz']), 'foobar');
 assert.equal(format('foo %s', ['foo']), 'foo foo')
 
 
-assert.equal(format(null, [null, 'foo']), null);
-assert.equal(format(null, [undefined, 'foo']), null);
+assert.equal(format(null, [null, 'foo']), 'null foo');
+assert.equal(format(null, [undefined, 'foo']), 'undefined foo');
 assert.equal(format(), util.format());
 assert.equal(format('foo %o', [{foo: 'foo'}]), 'foo {"foo":"foo"}')
 assert.equal(format('foo %O', [{foo: 'foo'}]), 'foo {"foo":"foo"}')

--- a/test/index.js
+++ b/test/index.js
@@ -1,9 +1,6 @@
 'use strict';
 const assert = require('assert');
 const format = require('../');
-const util = require('util');
-
-// const symbol = Symbol('foo');
 
 // assert.equal(format([]), '');
 // assert.equal(format(['']), '');
@@ -82,10 +79,6 @@ assert.equal(format('%s%s', ['foo', 'bar', 'baz']), 'foobar');
 
 assert.equal(format('foo %s', ['foo']), 'foo foo')
 
-
-assert.equal(format(null, [null, 'foo']), 'null foo');
-assert.equal(format(null, [undefined, 'foo']), 'undefined foo');
-assert.equal(format(), util.format());
 assert.equal(format('foo %o', [{foo: 'foo'}]), 'foo {"foo":"foo"}')
 assert.equal(format('foo %O', [{foo: 'foo'}]), 'foo {"foo":"foo"}')
 assert.equal(format('foo %j', [{foo: 'foo'}]), 'foo {"foo":"foo"}')
@@ -101,7 +94,6 @@ assert.equal(
 const circularObject = {}
 circularObject.foo = circularObject
 assert.equal(format('foo %j', [circularObject]), 'foo "[Circular]"')
-
 
 // // assert.equal(format(['%%%s%%', 'hi']), '%hi%');
 // // assert.equal(format(['%%%s%%%%', 'hi']), '%hi%%');


### PR DESCRIPTION
This reverts commit 858729a95933a2417f01cb198d808fe98d4167c6 and https://github.com/davidmarkclements/quick-format-unescaped/pull/24


See https://github.com/pinojs/pino/issues/983
Fixes https://github.com/davidmarkclements/quick-format-unescaped/issues/33